### PR TITLE
Bug fix: Add padding during bigInt to []byte conversion

### DIFF
--- a/client.go
+++ b/client.go
@@ -36,7 +36,7 @@ func NewClient(params *SRPParams, salt, identity, password, secret1 []byte) *SRP
 }
 
 func (c *SRPClient) ComputeA() []byte {
-	return intToBytes(c.A)
+	return padToN(c.A, c.Params)
 }
 
 // ComputeVerifier returns a verifier that is calculated as described in
@@ -55,8 +55,8 @@ func (c *SRPClient) SetB(Bb []byte) {
 	S := clientGetS(c.Params, c.Multiplier, c.X, c.Secret1, B, u)
 
 	c.K = getK(c.Params, S)
-	c.M1 = getM1(c.Params, intToBytes(c.A), Bb, S)
-	c.M2 = getM2(c.Params, intToBytes(c.A), c.M1, c.K)
+	c.M1 = getM1(c.Params, padToN(c.A, c.Params), Bb, S)
+	c.M2 = getM2(c.Params, padToN(c.A, c.Params), c.M1, c.K)
 
 	c.u = u               // Only for tests
 	c.s = intFromBytes(S) // Only for tests

--- a/server.go
+++ b/server.go
@@ -24,6 +24,7 @@ func NewServer(params *SRPParams, Vb []byte, S2b []byte) *SRPServer {
 	secret2 := intFromBytes(S2b)
 
 	Bb := getB(params, multiplier, V, secret2)
+
 	B := intFromBytes(Bb)
 
 	return &SRPServer{
@@ -35,7 +36,7 @@ func NewServer(params *SRPParams, Vb []byte, S2b []byte) *SRPServer {
 }
 
 func (s *SRPServer) ComputeB() []byte {
-	return intToBytes(s.B)
+	return padToN(s.B, s.Params)
 }
 
 func (s *SRPServer) SetA(A []byte) {
@@ -44,7 +45,7 @@ func (s *SRPServer) SetA(A []byte) {
 	S := serverGetS(s.Params, s.Verifier, AInt, s.Secret2, U)
 
 	s.K = getK(s.Params, S)
-	s.M1 = getM1(s.Params, A, intToBytes(s.B), S)
+	s.M1 = getM1(s.Params, A, padToN(s.B, s.Params), S)
 	s.M2 = getM2(s.Params, A, s.M1, s.K)
 
 	s.u = U               // only for tests

--- a/srp.go
+++ b/srp.go
@@ -1,46 +1,51 @@
 // Package srp is port of node-srp to Go.
 //
-//
 // To use SRP, first decide on they parameters you will use. Both client and server must
 // use the same set.
-//  params := srp.GetParams(4096)
+//
+//	params := srp.GetParams(4096)
 //
 // From the client... generate a new secret key, initialize the client, and compute A.
 // Once you have A, you can send A to the server.
-//  secret1 := srp.GenKey()
-//  client := NewClient(params, salt, identity, secret, a)
-//  srpA := client.computeA()
 //
-//  sendToServer(srpA)
+//	secret1 := srp.GenKey()
+//	client := NewClient(params, salt, identity, secret, a)
+//	srpA := client.computeA()
+//
+//	sendToServer(srpA)
 //
 // From the server... generate another secret key, initialize the server, and compute B.
 // Once you have B, you can send B to the client.
-//  secret2 := srp.GenKey()
-//  server := NewServer(params, verifier, secret2)
-//  srpB := client.computeB()
 //
-//  sendToClient(srpB)
+//	secret2 := srp.GenKey()
+//	server := NewServer(params, verifier, secret2)
+//	srpB := client.computeB()
+//
+//	sendToClient(srpB)
 //
 // Once the client received B from the server, it can compute M1 based on A and B.
 // Once you have M1, send M1 to the server.
-//  client.setB(srpB)
-//  srpM1 := client.ComputeM1()
-//  sendM1ToServer(srpM1)
+//
+//	client.setB(srpB)
+//	srpM1 := client.ComputeM1()
+//	sendM1ToServer(srpM1)
 //
 // Once the server receives M1, it can verify that it is correct. If checkM1() returns
 // an error, authentication failed. If it succeeds it should be sent to the client.
-//  srpM2, err := server.checkM1(srpM1)
+//
+//	srpM2, err := server.checkM1(srpM1)
 //
 // Once the client receives M2, it can verify that it is correct, and know that authentication
 // was successful.
-//  err = client.CheckM2(serverM2)
+//
+//	err = client.CheckM2(serverM2)
 //
 // Now that both client and server have completed a successful authentication, they can
 // both compute K independently. K can now be used as either a key to encrypt communication
 // or as a session ID.
-//  clientK := client.ComputeK()
-//  serverK := server.ComputeK()
 //
+//	clientK := client.ComputeK()
+//	serverK := server.ComputeK()
 package srp
 
 import (
@@ -67,9 +72,8 @@ func getK(params *SRPParams, S []byte) []byte {
 
 func getu(params *SRPParams, A, B *big.Int) *big.Int {
 	hashU := params.Hash.New()
-	hashU.Write(A.Bytes())
-	hashU.Write(B.Bytes())
-
+	hashU.Write(padToN(A, params))
+	hashU.Write(padToN(B, params))
 	return hashToInt(hashU)
 }
 


### PR DESCRIPTION
While debugging intermittent failure during SRP based login flow, we discovered that the library was not adding correct padding at certain places.
